### PR TITLE
Rename type system classes and add missing getters

### DIFF
--- a/wizwalker/__main__.py
+++ b/wizwalker/__main__.py
@@ -9,7 +9,7 @@ from click_default_group import DefaultGroup
 from loguru import logger
 
 from wizwalker import Wad, utils, ClientHandler
-from wizwalker.memory.hashmap import get_hash_map
+from wizwalker.memory.type_tree import get_hash_map
 from wizwalker.cli import run_cmd, dump_class_to_string, dump_class_to_json
 
 

--- a/wizwalker/memory/__init__.py
+++ b/wizwalker/memory/__init__.py
@@ -1,6 +1,6 @@
 from .handler import HookHandler
 from .hooks import *
-from . import hashmap
+from . import type_tree
 from .memory_object import MemoryObject
 from .memory_reader import MemoryReader
 from .memory_objects import *


### PR DESCRIPTION
The previous `hashmap.py` file provided means of extracting information from KI's dynamic type system for reflection. What we assumed to be a hash map, in fact, turned out to be a hash tree during later research.

Furthermore some class names were adjusted to match their real names and a couple of the trivial missing getters for information in memory were added.