### PR TITLE
Fixed tempest not being picked up by get_damaging_aoes()

### DIFF
--- a/wizwalker/combat/handler.py
+++ b/wizwalker/combat/handler.py
@@ -172,7 +172,7 @@ class CombatHandler:
 
             for effect in effects:
                 effect_type = await effect.maybe_read_type_name()
-                if effect_type.lower() in ("variable", "random"):
+                if effect_type.lower() in ("variable", "random", "variablespelleffect"):
                     for sub_effect in await effect.maybe_effect_list():
                         if await sub_effect.effect_target() in (
                             EffectTarget.enemy_team,
@@ -418,14 +418,14 @@ class AoeHandler(CombatHandler):
 
             to_cast = enchanted_aoes[0]
 
-            if to_cast.is_castable():
+            if await to_cast.is_castable():
                 await to_cast.cast(None)
 
         # no enchants so just cast card
         elif not enchants and unenchanted_aoes:
             to_cast = unenchanted_aoes[0]
 
-            if to_cast.is_castable():
+            if await to_cast.is_castable():
                 await to_cast.cast(None)
 
         # hand full of enchants or enchants + other cards

--- a/wizwalker/combat/handler.py
+++ b/wizwalker/combat/handler.py
@@ -172,7 +172,7 @@ class CombatHandler:
 
             for effect in effects:
                 effect_type = await effect.maybe_read_type_name()
-                if effect_type.lower() in ("variable", "random", "variablespelleffect"):
+                if any(substr in effect_type.lower() for substr in ("variable", "random")):
                     for sub_effect in await effect.maybe_effect_list():
                         if await sub_effect.effect_target() in (
                             EffectTarget.enemy_team,


### PR DESCRIPTION
## Rev2
Changed to a substring match, verified in game with tempest.

## Rev1
Was trying out `AoeHandler` and noticed that tempest wasn't being picked up as a damaging AOE. As you noted in the discord, tempest has the effect type `VariableSpellEffect` because it's an X cost spell.

I added that type to the effect_types checked by the handler and everything worked alright. I'm not sure why `VariableSpellEffect` 
 wasn't checked as I'm sure people realized tempest wasn't working. If there's a reason (like maybe it causes issues with other spells), I'll close the request.

Also added some awaits for async calls that weren't being awaited for.