### PR TITLE
Expand SpellEffects in enums.py

### DIFF
--- a/wizwalker/memory/memory_objects/enums.py
+++ b/wizwalker/memory/memory_objects/enums.py
@@ -235,6 +235,9 @@ class SpellEffects(Enum):
     remove_converted_charm = 144
     remove_converted_ward = 145
     remove_converted_over_time = 146
+    extend_damage_over_time = 147
+    extend_heal_over_time = 148
+    
 
 
 class EffectTarget(Enum):

--- a/wizwalker/memory/memory_objects/enums.py
+++ b/wizwalker/memory/memory_objects/enums.py
@@ -235,9 +235,7 @@ class SpellEffects(Enum):
     remove_converted_charm = 144
     remove_converted_ward = 145
     remove_converted_over_time = 146
-    extend_damage_over_time = 147
-    extend_heal_over_time = 148
-    
+    modify_over_time_duration = 147
 
 
 class EffectTarget(Enum):


### PR DESCRIPTION
Added support for 2 spell effects, 147 (extends a damage over time), and 148 (extends a heal over time). 
You can find examples of SpellEffect 147 in the spell "Blast Off!" or 147 and 148 (presumably) in the item card spell 'Duck Savage".
NOTE: 148 is inferred, not confirmed. 147 is confirmed to be ending a damage over time though.